### PR TITLE
change defined type plugin to class

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -3,7 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it 
 # under the terms of the GNU General Public License version 3 as published by
 # the Free Software Foundation.class 
-define x2go::plugin (
+class x2go::plugin (
   $ensure = present,
 ) {
   include x2go::repo


### PR DESCRIPTION
Setting x2go::plugin as defined type seemed wrong to me since calling it more than once would result in duplicate resources (i.e package{'x2goplugin'}. I've changed the type to  class.

Maybe we can get rid of the class at all since it's not included anywhere?