### PR TITLE
add upper bounds for dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,13 @@
   ],
   "description": "Puppet module for x2go client and server.",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 3.0.1"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.0"}
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 3.0.1 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
+    }
   ]
 }


### PR DESCRIPTION
add upper bounds for dependencies to follow [puppet best practices.](https://docs.puppet.com/puppet/latest/modules_metadata.html#best-practice-set-an-upper-bound-for-dependencies)
